### PR TITLE
feat(commit): Add --all, --amend, and issue referencing capabilities

### DIFF
--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -29,6 +29,11 @@ var commitCmd = &cobra.Command{
 			return fmt.Errorf("get prompt flag: %w", err)
 		}
 
+		issues, err := cmd.Flags().GetStringSlice(issuesFlagName)
+		if err != nil {
+			return fmt.Errorf("get issues flag: %w", err)
+		}
+
 		providerName, err := cmd.Flags().GetString(providerFlagName)
 		if err != nil {
 			return fmt.Errorf("get provider flag: %w", err)
@@ -52,7 +57,11 @@ var commitCmd = &cobra.Command{
 		ctx, cancel := context.WithTimeout(cmd.Context(), time.Minute*1)
 		defer cancel()
 
-		msg, err := provider.GenerateCommitMessage(ctx, diff, additionalPrompt)
+		msg, err := provider.GenerateCommitMessage(ctx, llm.GenerateCommitParams{
+			Diff:              diff,
+			Issues:            issues,
+			AdditionalContext: additionalPrompt,
+		})
 		if err != nil {
 			return fmt.Errorf("generate git commit: %w", err)
 		}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -22,7 +22,6 @@ import (
 const (
 	noTemplateFlagName = "no-template"
 	draftFlagName      = "draft"
-	issuesFlagName     = "issues"
 )
 
 func findPRTemplate(root string) (string, error) {
@@ -176,9 +175,6 @@ func init() {
 
 	prCmd.Flags().
 		Bool(draftFlagName, false, "Set this flag to create the PR as a draft")
-
-	prCmd.Flags().
-		StringSlice(issuesFlagName, nil, "Specifies the issues that are addressed by the PR.")
 
 	rootCmd.AddCommand(prCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ const (
 	providerFlagName = "provider"
 	headBranchFlag   = "head"
 	baseBranchFlag   = "base"
+	issuesFlagName   = "issues"
 )
 
 var rootCmd = &cobra.Command{
@@ -45,4 +46,8 @@ func init() {
 
 	rootCmd.PersistentFlags().String(baseBranchFlag, "main", "The destination branch")
 	rootCmd.PersistentFlags().String(headBranchFlag, "", "The origin branch")
+
+	rootCmd.PersistentFlags().
+		StringSlice(issuesFlagName, nil, "Specifies the issues that are addressed by the operation.")
+
 }

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -6,8 +6,20 @@ import (
 	"os/exec"
 )
 
-func CommitWithMessage(ctx context.Context, msg string) error {
-	cmd := exec.CommandContext(ctx, "git", "commit", "-em", msg)
+type CommitOption string
+
+const (
+	Amend CommitOption = "--amend"
+)
+
+func CommitWithMessage(ctx context.Context, msg string, options ...CommitOption) error {
+	args := make([]string, len(options))
+	for i, opt := range options {
+		args[i] = string(opt)
+	}
+	gitArgs := append([]string{"commit", "-em", msg}, args...)
+
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
 
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -10,6 +10,7 @@ type CommitOption string
 
 const (
 	Amend CommitOption = "--amend"
+	All   CommitOption = "--all"
 )
 
 func CommitWithMessage(ctx context.Context, msg string, options ...CommitOption) error {

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -22,8 +21,8 @@ type DiffOption string
 func (o DiffOption) String() string { return string(o) }
 func (o DiffOption) isDiffArg()     {}
 
-func Cached(target string) DiffOption {
-	return DiffOption(fmt.Sprintf("--cached %s", target))
+func Target(target string) DiffOption {
+	return DiffOption(target)
 }
 
 func Diff(ctx context.Context, options ...DiffArg) (string, error) {

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -2,7 +2,9 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"strings"
 )
 
 var (
@@ -10,7 +12,7 @@ var (
 	Stats  DiffOption = "--stat"
 )
 
-type diffArg interface {
+type DiffArg interface {
 	String() string
 	isDiffArg()
 }
@@ -20,10 +22,16 @@ type DiffOption string
 func (o DiffOption) String() string { return string(o) }
 func (o DiffOption) isDiffArg()     {}
 
-func Diff(ctx context.Context, options ...diffArg) (string, error) {
-	args := make([]string, len(options))
-	for i, opt := range options {
-		args[i] = opt.String()
+func Cached(target string) DiffOption {
+	return DiffOption(fmt.Sprintf("--cached %s", target))
+}
+
+func Diff(ctx context.Context, options ...DiffArg) (string, error) {
+	var args []string
+
+	for _, opt := range options {
+		parts := strings.Fields(opt.String())
+		args = append(args, parts...)
 	}
 	gitArgs := append([]string{"diff"}, args...)
 

--- a/internal/llm/gemini/gitcommit.go
+++ b/internal/llm/gemini/gitcommit.go
@@ -3,8 +3,11 @@ package gemini
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"google.golang.org/genai"
+
+	"github.com/arthvm/ditto/internal/llm"
 )
 
 func getCommitSystemPrompt(additionalContext string) string {
@@ -40,6 +43,22 @@ You are a Git and Conventional Commits expert. Your task is to analyze a Git dif
 4. Create a concise description (max 50 characters)
 5. If needed, add explanatory body after blank line
 6. For breaking changes, add '!' after type/scope and 'BREAKING CHANGE:' in footer
+7. Add a footer to reference the provided issues:
+	- Use Closes #<issue_number> if the commit type is fix or feat, as these changes typically resolve an issue.
+	- Use Refs #<issue_number> for all other commit types, as they are likely just related to the issue.
+		- If multiple issues are provided, list them grouped by keyword separated by commas. Each keywork should be in a new line. Example:
+			Closes #1, #2
+			Fixes #3
+	- Place the issues with an empty line bet
+	-  The footer must follow a specific structure. If a 'BREAKING CHANGE' is present, there must be a blank line separating it from the rest of the metadata. All subsequent metadata (issues, authors, reviewers) must form a single, contiguous block.
+		### Correct Formatting Example:
+		BREAKING CHANGE: Description of the breaking change goes here.
+		<-- There MUST be a blank line here.
+
+		Closes #123
+		Refs #456
+		Reviewed-by: Jane Doe <jane.doe@example.com>
+		Co-authored-by: John Smith <john.smith@example.com>
 
 ## Response format:
 Provide only the final commit message, without additional explanations.
@@ -52,8 +71,7 @@ Provide only the final commit message, without additional explanations.
 
 func (p *provider) GenerateCommitMessage(
 	ctx context.Context,
-	diff string,
-	additionalContext string,
+	params llm.GenerateCommitParams,
 ) (string, error) {
 	client, err := genai.NewClient(ctx, nil)
 	if err != nil {
@@ -62,15 +80,24 @@ func (p *provider) GenerateCommitMessage(
 
 	config := &genai.GenerateContentConfig{
 		SystemInstruction: genai.NewContentFromText(
-			getCommitSystemPrompt(additionalContext),
+			getCommitSystemPrompt(params.AdditionalContext),
 			genai.RoleUser,
 		),
 	}
 
+	context := fmt.Sprintf(`
+	--- DIFF START ---
+	%s
+	--- DIFF END ---
+	--- RELATED ISSUES START ---
+	%s
+	--- RELATED ISSUES END ---
+		`, params.Diff, strings.Join(params.Issues, "\n"))
+
 	result, err := client.Models.GenerateContent(
 		ctx,
 		p.model,
-		genai.Text(diff),
+		genai.Text(context),
 		config,
 	)
 	if err != nil {

--- a/internal/llm/ollama/gitcommit.go
+++ b/internal/llm/ollama/gitcommit.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+
+	"github.com/arthvm/ditto/internal/llm"
 )
 
 func (p *provider) GenerateCommitMessage(
 	ctx context.Context,
-	diff string,
-	additionalContext string,
+	params llm.GenerateCommitParams,
 ) (string, error) {
 	baseUrl, exists := os.LookupEnv("OLLAMA_HOST")
 	if !exists {
@@ -23,7 +24,7 @@ func (p *provider) GenerateCommitMessage(
 
 	body := generateRequestBody{
 		Model:  p.model,
-		Prompt: diff,
+		Prompt: params.Diff,
 		Stream: false,
 		Raw:    false,
 	}

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -22,8 +22,14 @@ type GeneratePrParams struct {
 	AdditionalContext string
 }
 
+type GenerateCommitParams struct {
+	Diff              string
+	Issues            []string
+	AdditionalContext string
+}
+
 type Provider interface {
-	GenerateCommitMessage(context.Context, string, string) (string, error)
+	GenerateCommitMessage(context.Context, GenerateCommitParams) (string, error)
 	GeneratePr(context.Context, GeneratePrParams) (string, error)
 }
 


### PR DESCRIPTION
This pull request significantly enhances the `commit` command by introducing new flags for more flexible workflows and enabling automatic issue referencing in generated messages.

### What & Why
The `commit` command is updated to support amending previous commits, committing all tracked changes, and including issue references. These changes align its functionality more closely with the native `git commit` command and improve integration with issue trackers.

### How
- **`--all` (`-a`) flag**: A new flag has been added to commit all tracked file changes, not just those that are staged.
- **`--amend` flag**: This flag allows amending the previous commit by incorporating the current changes. The diff is generated against `HEAD^`. The logic correctly handles combinations, e.g., `commit -a --amend` diffs all tracked files against `HEAD^`.
- **Issue Referencing**: The `--issues` flag has been promoted to a persistent flag on the root command. The `commit` command now passes these issue numbers to the LLM provider, enabling it to include formatted references in the commit message footer.

### Testing
These changes have been tested manually by executing the `commit` command with the new flags and their combinations:
- `commit -a`
- `commit --amend`
- `commit -a --amend`
- `commit --issues <id>`

Verified that the correct diff is generated and the appropriate `git commit` command is executed in each case.

### Breaking Changes
- **BREAKING CHANGE**: The `GenerateCommitMessage` method signature in the `llm.Provider` interface has been updated from `(context.Context, string, string)` to `(context.Context, llm.GenerateCommitParams)` to support passing issue numbers. All existing LLM provider implementations have been updated accordingly.

### Related Issues
Closes #6